### PR TITLE
 Use callObjectAdded helper in case objectAdded is null

### DIFF
--- a/js/multiselector.js
+++ b/js/multiselector.js
@@ -551,7 +551,7 @@
                                 helpers.highlightItem();
                                 $("ul.multiselector-selection-"+wrapperId).find(".token-input").val("").focus();
                                 helpers.toggleShowAllButton(false);
-                                multiSelector.options.objectAdded(objectId);
+				helpers.callObjectAdded(objectId);
                                 helpers.updateInputWidth();
 
                                 return;


### PR DESCRIPTION
This is tidy-up from some of the changes we did to multiselector on our end, it was causing part of the demo to break.
